### PR TITLE
Switch to base32 implementation from `rfc4648`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ var hex = value.toString(16);
 
 var encoded = hexTo32.encode(hex);
 
-assert.equal(encoded, "32W2K");
+assert.equal(encoded, "32w2k");
 
 var decoded = hexTo32.decode(encoded);
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # hex-to-32
-Convert a hex string to base32 and back.
 
-Uses [this](https://github.com/agnoster/base32-js) human-friendly base32 implementation.
+Convert a hex string to base32 and back using [`rfc4648`](https://www.npmjs.com/package/rfc4648).
 
 ```
 npm install --save hex-to-32
@@ -14,7 +13,7 @@ var hex = value.toString(16);
 
 var encoded = hexTo32.encode(hex);
 
-assert.equal(encoded, "vupua");
+assert.equal(encoded, "32W2K");
 
 var decoded = hexTo32.decode(encoded);
 

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ function encode(hexString) {
 	var bytes = Buffer.from(hexString, "hex");
 	var encoded = base32.stringify(bytes);
 
-	// strip padding
-	return encoded.replace(/(=+)$/, '');
+	// strip padding & lowercase
+	return encoded.replace(/(=+)$/, '').toLowerCase();
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var base32 = require("base32");
+var { base32 } = require('rfc4648')
 
 module.exports = {
 	encode: encode,
@@ -12,8 +12,10 @@ module.exports = {
 function encode(hexString) {
 	// Convert to array of bytes
 	var bytes = Buffer.from(hexString, "hex");
+	var encoded = base32.stringify(bytes);
 
-	return base32.encode(bytes);
+	// strip padding
+	return encoded.replace(/(=+)$/, '');
 }
 
 /**
@@ -21,11 +23,11 @@ function encode(hexString) {
  * @param {String} base32String The base32 encoded string
  */
 function decode(base32String) {
-	// Decode to ascii text
-	var ascii = base32.decode(base32String);
-
-	// Convert to array of bytes
-	var bytes = Buffer.from(ascii, "ascii");
+	// Decode to Buffer
+	var bytes = base32.parse(base32String, {
+		out: Buffer.alloc,
+		loose: true
+	});
 
 	return bytes.toString("hex");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,35 +1,13 @@
 {
   "name": "hex-to-32",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "base32": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/base32/-/base32-0.0.6.tgz",
-      "integrity": "sha1-eQOLy1rsLY8ivMHChAKST1Cm0qw=",
-      "requires": {
-        "optimist": "0.6.1"
-      }
-    },
-    "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
-      }
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    "rfc4648": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.1.0.tgz",
+      "integrity": "sha512-ExPH8PFXP8Qq//GU6lk23BlHhWdIf1EYP427wJjvF+8ybn3lWTkCRB+JCPRs7vrSw2+IcoyeSqMSWqd1Z/4rIQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hex-to-32",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Convert a hex string to base32 and back",
   "main": "index.js",
   "scripts": {
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/RangerMauve/hex-to-32#readme",
   "dependencies": {
-    "base32": "0.0.6"
+    "rfc4648": "^1.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ var assert = require("assert");
 var hexTo32 = require(".");
 
 var value = 0xDEADA5;
-var expected = "32W2K";
+var expected = "32w2k";
 
 var hex = value.toString(16);
 

--- a/test.js
+++ b/test.js
@@ -5,13 +5,14 @@
 var assert = require("assert");
 var hexTo32 = require(".");
 
-var value = 0xDEADA5; // vupua
+var value = 0xDEADA5;
+var expected = "32W2K";
 
 var hex = value.toString(16);
 
 var encoded = hexTo32.encode(hex);
 
-assert.equal(encoded, "vupua", "Encoded value is unexpected");
+assert.equal(encoded, expected, "Encoded value is unexpected");
 
 var decoded = hexTo32.decode(encoded);
 


### PR DESCRIPTION
This should address [this issue](https://github.com/RangerMauve/dat-gateway/issues/11) over at `dat-gateway`. It's a breaking change, because RFC-4648 gives a different output than the other module apparently. To account for that I've already upped the version number.